### PR TITLE
optimized matching and reformated code

### DIFF
--- a/r2_chatterbot/util/nlp_util.py
+++ b/r2_chatterbot/util/nlp_util.py
@@ -2,7 +2,8 @@ import os
 import re  # regex module
 import nltk
 from util import utils
-# import utils
+#import utils
+import itertools
 
 
 def parse(line, expression, custom_tags=[]):
@@ -150,7 +151,7 @@ def match_regex_and_keywords(line, exp, custom_tags=[], keywords=None):
     any keywords are in the chunk
 
     @param line: The sentence to check
-    @param expression: A raw string containing the regular expression
+    @param expression: A list containing the regular expressions
             chunk to match. This is utilizing nltk's regex parser
     @param keywords: Optional. An array containing keywords to match.
             Can also require keywords to appear only in certain chunks.
@@ -163,7 +164,26 @@ def match_regex_and_keywords(line, exp, custom_tags=[], keywords=None):
     '''
     matched_chunks = []
     matched_keywords = []
-    tree = parse(line, exp, custom_tags)
+    # find all possible permutation of the regex
+    expressions = list(itertools.permutations(exp, len(exp)))
+    minLen = float('inf')
+    minIndex = -1
+    # find the regex so that the tree has the least number of subtrees in order to maximize matching
+    for i, expression in enumerate(expressions):
+        expr = ""
+        for e in expression:
+            expr = expr+e
+            expr = expr+"\n"
+        tree = parse(line, expr, custom_tags)
+        if (len(tree) < minLen):
+            minIndex = i
+            minLen = len(tree)
+    # construct the optimal regex
+    expr = ""
+    for e in expressions[minIndex]:
+        expr = expr+e
+        expr = expr+"\n"
+    tree = parse(line, expr, custom_tags)
     # only loop over full trees, not subtrees or leaves
     # only root node has the "S" label
     for subtree in tree.subtrees(lambda t: t.label() == "S"):

--- a/r2_chatterbot/util/nlp_util.py
+++ b/r2_chatterbot/util/nlp_util.py
@@ -167,7 +167,7 @@ def match_regex_and_keywords(line, exp, custom_tags=[], keywords=None):
     # find all possible permutation of the regex
     expressions = list(itertools.permutations(exp, len(exp)))
     minLen = float('inf')
-    minIndex = -1
+    minIndex = 0
     # find the regex so that the tree has the least number of subtrees in order to maximize matching
     for i, expression in enumerate(expressions):
         expr = ""

--- a/r2_chatterbot/util/path_planning.py
+++ b/r2_chatterbot/util/path_planning.py
@@ -17,7 +17,8 @@ commands = ["move", "spin", "rotate", "turn", "go", "drive", "stop", "travel"]
 
 custom_tags = [(d, "D") for d in directions] + [(c, "V") for c in commands]
 custom_tags.append(("a", "A"))
-custom_tags_obstacle = [(d, "D") for d in directions_obstacles] + [(c, "V") for c in commands]
+custom_tags_obstacle = [
+    (d, "D") for d in directions_obstacles] + [(c, "V") for c in commands]
 custom_tags_obstacle.append(("a", "A"))
 
 # defining constants for small movements
@@ -46,16 +47,14 @@ def preprocess(text):
 
 def test_locphrase(text):
     # experimental function for different regex parsing
-    expr = r"""
-    DirectionFirst: {(((<TO|IN>)<DT>)?<D><CD><NNS|NN|JJ>?)}
-    NumberFirst: {(<CD><NNS|NN|JJ>?((<TO|IN>)<DT>)?<D>)}
-    LittleDirection: {(((<TO|IN>)<DT>)?<D><A><NNS|NN|JJ>?<NN>?)}
-    LittleNumber: {(<A><NNS|NN|JJ>?<NN>?((<TO|IN>)<DT>)?<D>)}
-    Obstacle: {(((<TO|IN>)<DT>)?<D>)}
-    """
+    expr = ["DirectionFirst: {(((<TO|IN>)<DT>)?<D><CD><NNS|NN|JJ>?)}",
+            "NumberFirst: {(<CD><NNS|NN|JJ>?((<TO|IN>)<DT>)?<D>)}",
+            "LittleDirection: {(((<TO|IN>)<DT>)?<D><A><NNS|NN|JJ>?<NN>?)}",
+            "LittleNumber: {(<A><NNS|NN|JJ>?<NN>?((<TO|IN>)<DT>)?<D>)}",
+            "Obstacle: {(((<TO|IN>)<DT>)?<D>)}"]
     locPhrase, keywords = nlp_util.match_regex_and_keywords(
         text, expr, custom_tags=custom_tags)
-    print(locPhrase)
+    # print(locPhrase)
 
     return locPhrase
 
@@ -67,21 +66,17 @@ def get_locphrase(text):
 
     @param text: the original text (must be in lowercase)
     """
-    expr = r"""
-    DirectionFirst: {(((<TO|IN>)<DT>)?<D><CD><NNS|NN|JJ>?)}
-    NumberFirst: {(<CD><NNS|NN|JJ>?((<TO|IN>)<DT>)?<D>)}
-    LittleDirection: {(((<TO|IN>)<DT>)?<D><A><NNS|NN|JJ>?<NN>?)}
-    LittleNumber: {(<A><NNS|NN|JJ>?<NN>?((<TO|IN>)<DT>)?<D>)}
-    Obstacle: {(((<TO|IN>)<DT>)?<D>)}
-    """
+    expr = ["DirectionFirst: {(((<TO|IN>)<DT>)?<D><CD><NNS|NN|JJ>?)}",
+            "NumberFirst: {(<CD><NNS|NN|JJ>?((<TO|IN>)<DT>)?<D>)}",
+            "LittleDirection: {(((<TO|IN>)<DT>)?<D><A><NNS|NN|JJ>?<NN>?)}",
+            "LittleNumber: {(<A><NNS|NN|JJ>?<NN>?((<TO|IN>)<DT>)?<D>)}",
+            "Obstacle: {(((<TO|IN>)<DT>)?<D>)}"]
     locPhrase, keywords = nlp_util.match_regex_and_keywords(
         text, expr, custom_tags=custom_tags)
 
     if len(locPhrase) <= 0 or locPhrase[0].label() == "S":
         # didn't get a match before, try only looking for obstacle commands
-        expr_obstacle = r"""
-        Obstacle: {(((<TO|IN>)<DT>)?<D>)}
-        """
+        expr_obstacle = ["Obstacle: {(((<TO|IN>)<DT>)?<D>)}"]
         locPhrase, keywords = nlp_util.match_regex_and_keywords(
             text, expr_obstacle, custom_tags=custom_tags_obstacle)
     print(locPhrase)
@@ -187,6 +182,184 @@ def get_loc_params(phrase, label, mode=None):
     return float(number), unit, direction
 
 
+def multiple_mixed_command(locPhrase, keyword, modes):
+    """
+    Precondition: commands from mode move or turn joined by "and", and "move" and "turn" 
+    has to be said for every single command
+
+    Return a list of coordinate in the form of (x-pos, y-pos, faced direction)
+    forward indicates positive y, right indicate positive x
+    eg. [(14.0, 0.0, 0), (14.0, 0.0, 30.0), (17.05, -5.28, -60.0)]
+
+    Note: when move left or right, the direction the robot is facing are will also -90 or +90 respectively
+    """
+    command = []
+    x = 0
+    y = 0
+    degree = 0
+    prev_unit = None
+    for i, phrase in enumerate(locPhrase):
+        number, unit, direction = get_loc_params(
+            locPhrase[i], locPhrase[i].label(), modes[i])
+        if(keyword[i] == "stop"):
+            return(command)
+        elif(keyword[i] == "turn"):
+            if unit == "radian":
+                number = number * 180 / math.pi
+            if direction == "left" or direction == "counterclockwise":
+                number = -1 * number
+            degree += number
+            command.append((float(round(x, 2)), float(round(y, 2)), degree))
+        elif(keyword[i] == "move"):
+            if unit == "dimensionless":
+                if prev_unit:
+                    unit = prev_unit
+                else:
+                    unit = "metre"
+                    prev_unit = "unit"
+            else:
+                prev_unit = unit
+            if unit == "foot":
+                number = number * 0.3048
+            if direction == "forward":
+                x += number*math.cos(math.radians(degree))
+                y += number*math.sin(math.radians(degree))
+            elif direction == "left":
+                degree = degree-90
+                x += number*math.cos(math.radians(degree))
+                y += number*math.sin(math.radians(degree))
+            elif direction == "right":
+                degree = degree+90
+                x += number*math.cos(math.radians(degree))
+                y += number*math.sin(math.radians(degree))
+            elif direction == "backward":
+                x -= number*math.cos(math.radians(degree))
+                y -= number*math.sin(math.radians(degree))
+            command.append((float(round(x, 2)), float(round(y, 2)), degree))
+            # if the unit isn't provided, assume it's the same
+            # as the previous unit - if that's unspecified, assume meters
+    return (command)
+
+
+def multiple_turn_commands(locPhrase):
+    """
+    Precondition: >2 commands of turns joined by "and" without having to say "turn" multiple times
+    Return a tuple with "turn" and list of final degrees
+    eg. ('turn', [14.0, -6.0, -46.0])
+    """
+    command = []
+    final_degree = 0
+    for phrase in locPhrase:
+        number, unit, direction = get_loc_params(phrase, phrase.label(), 1)
+        # number, unit, direction = get_loc_params_b(phrase, mode)
+        # if the unit isn't provided, assume it's the same
+        # as the previous unit - if that's unspecified, assume meters
+        # print(number, unit, direction)
+        if unit == "radian":
+            number = number * 180 / math.pi
+        if direction == "left" or direction == "counterclockwise":
+            number = -1 * number
+        final_degree = final_degree + number
+        command.append(round(final_degree, 2))
+    return ("turn", command)
+
+
+def two_turn_commands(locPhrase):
+    """
+    Precondition: 2 commands of turns joined by "and" without having to say "turn" multiple times
+    Return a tuple with "turn" and the final degrees
+    eg. ('turn', -6.0)
+    """
+    final_degree = 0
+    for phrase in locPhrase:
+        number, unit, direction = get_loc_params(
+            phrase, phrase.label(), 1)
+        # number, unit, direction = get_loc_params_b(phrase, mode)
+        # if the unit isn't provided, assume it's the same
+        # as the previous unit - if that's unspecified, assume meters
+        # print(number, unit, direction)
+        if unit == "radian":
+            number = number * 180 / math.pi
+        if direction == "left" or direction == "counterclockwise":
+            number = -1 * number
+        final_degree = final_degree+number
+    return ("turn", round(final_degree, 2))
+
+
+def multiple_move_commands(locPhrase):
+    """
+    Precondition: >2 commands of moves joined by "and" without having to say "move" multiple times
+    Return a tuple with "move" and list of coordinate in the form of (x-pos, y-pos)
+    eg. ('move', [(0.0, 14.0), (30.0, 14.0), (23.9, 14.0)])
+    """
+    command = []
+    x = 0
+    y = 0
+    prev_unit = None
+    for phrase in locPhrase:
+        number, unit, direction = get_loc_params(phrase, phrase.label(), 2)
+        # number, unit, direction = get_loc_params_b(phrase, mode)
+        # if the unit isn't provided, assume it's the same
+        # as the previous unit - if that's unspecified, assume meters
+        # print(number, unit, direction)
+        if unit == "dimensionless":
+            if prev_unit:
+                unit = prev_unit
+            else:
+                unit = "metre"
+                prev_unit = unit
+        else:
+            prev_unit = unit
+        if unit == "foot":
+            number = number * 0.3048
+        if direction == "forward":
+            y += number
+        elif direction == "left":
+            x -= number
+        elif direction == "right":
+            x += number
+        elif direction == "backward" or direction == "backwards":
+            y -= number
+        command.append((float(round(x, 2)), float(round(y, 2))))
+    return ("move", command)
+
+
+def two_move_commands(locPhrase):
+    """
+    Precondition: 2 commands of moves joined by "and" without having to say "move" multiple times
+    Return the final coordinate in the form of (x-pos, y-pos)
+    eg. (-0.91, 0.3)
+    """
+    x = 0
+    y = 0
+    prev_unit = None
+    for phrase in locPhrase:
+        number, unit, direction = get_loc_params(phrase, phrase.label(), 2)
+        # number, unit, direction = get_loc_params_b(phrase, mode)
+        # if the unit isn't provided, assume it's the same
+        # as the previous unit - if that's unspecified, assume meters
+        # print(number, unit, direction)
+        if unit == "dimensionless":
+            if prev_unit:
+                unit = prev_unit
+            else:
+                unit = "metre"
+                prev_unit = unit
+        else:
+            prev_unit = unit
+        if unit == "foot":
+            number = number * 0.3048
+        if direction == "forward":
+            y += number
+        elif direction == "left":
+            x -= number
+        elif direction == "right":
+            x += number
+        elif direction == "backward" or direction == "backwards":
+            y -= number
+    return (float(round(x, 2)), float(round(y, 2)))
+
+
 def process_loc(text):
     """
     Returns a tuple value specifying how CICO should move.
@@ -202,10 +375,10 @@ def process_loc(text):
     #                    for tup in tagged_list if tup[1] == 'NN' or tup[1] == 'VB' or tup[1] == 'VBP']
     # # DEBUG THISSSS
     words = nltk.word_tokenize(text)
-    command = []
     keyword = {}
     modes = {}
     i = 0
+    # preprocess the locPhase tree
     for verb in words:
         if verb == "stop":
             keyword[i] = "stop"
@@ -219,178 +392,36 @@ def process_loc(text):
             keyword[i] = "move"
             modes[i] = 2
             i = i+1
-    for verb in words:
-        if verb == "stop":
+        if(modes[0] == 0):
             return ("stop", 0)
-        elif verb in ["turn", "spin", "rotate"]:
+        elif(modes[0] == 1):
             mode = 1
-            break
-        elif verb in ["move", "go", "drive", "travel"]:
+        elif (modes[0] == 2):
             mode = 2
-            break
     if len(locPhrase) > 1 and len(locPhrase) == i:
-        # print("multiple")
-        x = 0
-        y = 0
-        degree = 0
-        prev_unit = None
-        for i, phrase in enumerate(locPhrase):
-            number, unit, direction = get_loc_params(
-                locPhrase[i], locPhrase[i].label(), modes[i])
-            if(keyword[i] == "stop"):
-                return(command)
-            elif(keyword[i] == "turn"):
-                if unit == "radian":
-                    number = number * 180 / math.pi
-                if direction == "left" or direction == "counterclockwise":
-                    number = -1 * number
-                degree += number
-                command.append(
-                    (float(round(x, 2)), float(round(y, 2)), degree))
-            elif(keyword[i] == "move"):
-                if unit == "dimensionless":
-                    if prev_unit:
-                        unit = prev_unit
-                    else:
-                        unit = "metre"
-                        prev_unit = "unit"
-                else:
-                    prev_unit = unit
-                if unit == "foot":
-                    number = number * 0.3048
-                if direction == "forward":
-                    x += number*math.cos(math.radians(degree))
-                    y += number*math.sin(math.radians(degree))
-                elif direction == "left":
-                    degree = degree-90
-                    x += number*math.cos(math.radians(degree))
-                    y += number*math.sin(math.radians(degree))
-                elif direction == "right":
-                    degree = degree+90
-                    x += number*math.cos(math.radians(degree))
-                    y += number*math.sin(math.radians(degree))
-                elif direction == "backward":
-                    x -= number*math.cos(math.radians(degree))
-                    y -= number*math.sin(math.radians(degree))
-                command.append(
-                    (float(round(x, 2)), float(round(y, 2)), degree))
-            # if the unit isn't provided, assume it's the same
-            # as the previous unit - if that's unspecified, assume meters
-        return (command)
-    # print(locPhrase)
-    elif mode == 1:
+        return multiple_mixed_command(locPhrase, keyword, modes)
+    elif mode == 1:  # turn commands
         if len(locPhrase) > 2:
-            command = []
-            final_degree = 0
-
-            for phrase in locPhrase:
-                number, unit, direction = get_loc_params(
-                    phrase, phrase.label(), mode)
-                # number, unit, direction = get_loc_params_b(phrase, mode)
-                # if the unit isn't provided, assume it's the same
-                # as the previous unit - if that's unspecified, assume meters
-                # print(number, unit, direction)
-                if unit == "radian":
-                    number = number * 180 / math.pi
-                if direction == "left" or direction == "counterclockwise":
-                    number = -1 * number
-                final_degree = final_degree+number
-                command.append(round(final_degree, 2))
-            return ("turn", command)
+            return multiple_turn_commands(locPhrase)
         elif len(locPhrase) > 1:
-            final_degree = 0
-            for phrase in locPhrase:
-                number, unit, direction = get_loc_params(
-                    phrase, phrase.label(), mode)
-                # number, unit, direction = get_loc_params_b(phrase, mode)
-                # if the unit isn't provided, assume it's the same
-                # as the previous unit - if that's unspecified, assume meters
-                # print(number, unit, direction)
-                if unit == "radian":
-                    number = number * 180 / math.pi
-                if direction == "left" or direction == "counterclockwise":
-                    number = -1 * number
-                final_degree = final_degree+number
-            return ("turn", round(final_degree, 2))
-        else:
+            return two_turn_commands(locPhrase)
+        else:  # singular turn command
             number, unit, direction = get_loc_params(
                 locPhrase[0], locPhrase[0].label(), mode)
-        # print("here"+text)
-        # number, unit, direction = get_loc_params_b(locPhrase[0], mode)
-        # print(number)
             if unit == "radian":
                 number = number * 180 / math.pi
             if direction == "left" or direction == "counterclockwise":
                 number = -1 * number
             return ("turn", round(number, 2))
-    elif mode == 2:
+    elif mode == 2:  # move command
         if len(locPhrase) > 2:
-            command = []
-            x = 0
-            y = 0
-            prev_unit = None
-            for phrase in locPhrase:
-                number, unit, direction = get_loc_params(
-                    phrase, phrase.label(), mode)
-                # number, unit, direction = get_loc_params_b(phrase, mode)
-                # if the unit isn't provided, assume it's the same
-                # as the previous unit - if that's unspecified, assume meters
-                # print(number, unit, direction)
-                if unit == "dimensionless":
-                    if prev_unit:
-                        unit = prev_unit
-                    else:
-                        unit = "metre"
-                        prev_unit = unit
-                else:
-                    prev_unit = unit
-                if unit == "foot":
-                    number = number * 0.3048
-                if direction == "forward":
-                    y += number
-                elif direction == "left":
-                    x -= number
-                elif direction == "right":
-                    x += number
-                elif direction == "backward" or direction == "backwards":
-                    y -= number
-                command.append((float(round(x, 2)), float(round(y, 2))))
-            return ("move", command)
+            return multiple_move_commands(locPhrase)
         elif len(locPhrase) > 1:
-            x = 0
-            y = 0
-            prev_unit = None
-            for phrase in locPhrase:
-                number, unit, direction = get_loc_params(
-                    phrase, phrase.label(), mode)
-                # number, unit, direction = get_loc_params_b(phrase, mode)
-                # if the unit isn't provided, assume it's the same
-                # as the previous unit - if that's unspecified, assume meters
-                # print(number, unit, direction)
-                if unit == "dimensionless":
-                    if prev_unit:
-                        unit = prev_unit
-                    else:
-                        unit = "metre"
-                        prev_unit = unit
-                else:
-                    prev_unit = unit
-                if unit == "foot":
-                    number = number * 0.3048
-                if direction == "forward":
-                    y += number
-                elif direction == "left":
-                    x -= number
-                elif direction == "right":
-                    x += number
-                elif direction == "backward" or direction == "backwards":
-                    y -= number
-            return (float(round(x, 2)), float(round(y, 2)))
-        elif len(locPhrase) > 0:
+            return two_move_commands(locPhrase)
+        elif len(locPhrase) > 0:  # singular move command or move until an obstacle
             number, unit, direction = get_loc_params(
                 locPhrase[0], locPhrase[0].label(), mode)
-            # number, unit, direction = get_loc_params_b(locPhrase[0],mode)
-            if(unit == -1):
+            if(unit == -1):  # move until an obstacle
                 return ("keep moving", direction)
             if unit == "foot":
                 number = number * 0.3048
@@ -405,7 +436,6 @@ def process_loc(text):
                 return (0.0, -number)
             else:
                 return ("unknown", 0)
-
     return "Not processed"
 
 

--- a/r2_chatterbot/util/tests/path_planning_phrases.txt
+++ b/r2_chatterbot/util/tests/path_planning_phrases.txt
@@ -56,4 +56,4 @@
 ("turn 14 degrees clockwise, and 20 degrees to the left, and 40 counterclockwise", True, ('turn',[14.0, -6.0, -46.0]))
 ("move forward 14 meters,and to the right 30, and left 20 feet", True, ('move', [(0.0, 14.0), (30.0, 14.0), (23.9, 14.0)]))
 ("move forward and left a little bit", False)
-("move five feet forward, 3 meters to the right, and 2 backward", False)
+("move five feet forward, 3 meters to the right, and 2 backward", True, ('move', [(0.0, 1.52), (3.0, 1.52), (3.0, -0.48)]))


### PR DESCRIPTION
I have reformatted the code in path planning by break down the big chunk of process_loc code into sub-functions.
In addition, I have noticed that because the quantulum3 parser will default take the first regex matching it finds from the regex string. So I have decided to input the regex into the match function as a list and permutate all the potential ordering and find the regex order that would produce the least number of tree branches, which means the matching is optimized. 